### PR TITLE
Fix SetNameFunctionMixin logic. 

### DIFF
--- a/Common/src/main/java/brightspark/asynclocator/mixins/SetNameFunctionMixin.java
+++ b/Common/src/main/java/brightspark/asynclocator/mixins/SetNameFunctionMixin.java
@@ -21,12 +21,12 @@ public class SetNameFunctionMixin {
 		)
 	)
 	public ItemStack deferSetName(ItemStack stack, Component name) {
-		if (Services.CONFIG.explorationMapEnabled()) {
+		if (Services.CONFIG.explorationMapEnabled() && CommonLogic.isEmptyPendingMap(stack)) {
 			ALConstants.logDebug("Intercepted SetNameFunction#run call");
-			if (CommonLogic.isEmptyPendingMap(stack))
-				ExplorationMapFunctionLogic.cacheName(stack, name);
-		} else
+			ExplorationMapFunctionLogic.cacheName(stack, name);
+		} else {
 			stack.setHoverName(name);
+		}
 		return stack;
 	}
 }


### PR DESCRIPTION
Move the isEmtpyPendingMap check into the initial if conditions to allow the else to set the name of non-map items

Fixes #12 